### PR TITLE
Handle Gemini CLI reinstall ENOTEMPTY errors

### DIFF
--- a/update-ai-tools.js
+++ b/update-ai-tools.js
@@ -52,9 +52,7 @@ function removeGeminiInstallDir() {
   if (!existsSync(geminiDir)) {
     try {
       if (existsSync(geminiNamespaceDir)) {
-        const staleDirs = readdirSync(geminiNamespaceDir).filter((entry) =>
-          entry.startsWith(".gemini-cli")
-        );
+        const staleDirs = readdirSync(geminiNamespaceDir).filter((entry) => entry.startsWith(".gemini-cli"));
 
         staleDirs.forEach((entry) => {
           const dirPath = join(geminiNamespaceDir, entry);
@@ -71,9 +69,7 @@ function removeGeminiInstallDir() {
     rmSync(geminiDir, { recursive: true, force: true });
 
     if (existsSync(geminiNamespaceDir)) {
-      const staleDirs = readdirSync(geminiNamespaceDir).filter((entry) =>
-        entry.startsWith(".gemini-cli")
-      );
+      const staleDirs = readdirSync(geminiNamespaceDir).filter((entry) => entry.startsWith(".gemini-cli"));
 
       staleDirs.forEach((entry) => {
         const dirPath = join(geminiNamespaceDir, entry);
@@ -144,7 +140,7 @@ function compareVersions(v1, v2) {
 
 function getBinaryVersion(binaryName) {
   try {
-    const output = execSync(`${binaryName} --version`, { encoding: "utf8" }).trim();
+    const output = execSync(`${binaryName} --version`, { encoding: "utf8", stdio: "pipe" }).trim();
 
     // Handle copilot which returns multiple lines
     if (binaryName === "copilot") {
@@ -421,18 +417,14 @@ async function installPackages(packageList, individual = false) {
 
         if (message.includes("ENOTEMPTY") && message.includes("@google/gemini-cli")) {
           geminiCleanupAttempted = true;
-          console.log(
-            "🧹 Detected existing Gemini CLI install directory, removing before retry..."
-          );
+          console.log("🧹 Detected existing Gemini CLI install directory, removing before retry...");
 
           if (removeGeminiInstallDir()) {
             console.log("✅ Removed existing Gemini CLI directory. Retrying installation...");
             return { retryImmediately: true };
           }
 
-          console.log(
-            "⚠️  Automatic cleanup failed. You may need to close running processes and try again."
-          );
+          console.log("⚠️  Automatic cleanup failed. You may need to close running processes and try again.");
         }
 
         return null;


### PR DESCRIPTION
## Summary
- add helpers to detect the global npm directory and remove stale Gemini CLI folders when ENOTEMPTY occurs
- extend the retry helper to support custom error hooks so installs can run targeted remediation
- automatically clean and retry Gemini CLI installs that fail because an existing directory blocks npm

## Testing
- node --check update-ai-tools.js

------
https://chatgpt.com/codex/tasks/task_e_68f915b91d288328bcf5b32bc0949b1a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Gemini CLI installation conflicts with automatic cleanup, immediate retry, and clearer success/failure messaging to resolve installation failures.

* **Chores**
  * Enhanced AI tools installer robustness with global discovery and removal of stale installation directories, reducing deployment flakiness and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->